### PR TITLE
chore(cli): make --help cmd exit normally without error log

### DIFF
--- a/aenv/src/cli/cmds/common.py
+++ b/aenv/src/cli/cmds/common.py
@@ -81,6 +81,9 @@ def global_error_handler(func):
             logger.info("Operation interrupted by user")
             click.secho("\n⚠️ Operation cancelled", fg="yellow", err=True)
             sys.exit(130)
+        except click.exceptions.Exit:
+            # Exit exceptions are normal (e.g., --help), let Click handle them
+            raise
         except click.ClickException as e:
             _handle_click_error(e)
             sys.exit(e.exit_code)


### PR DESCRIPTION
Remove the false alarm error message in cli.

Before:
```
❯ aenv build --help
Usage: aenv build [OPTIONS]

  Build Docker images with real-time progress display.

  This command builds Docker images from your project and provides real-time
  progress updates with beautiful UI components.

  Examples:     aenv build     aenv build --image-name myapp --image-tag v1.0
  aenv build --work-dir ./myproject --registry myregistry.com

Options:
  -w, --work-dir DIRECTORY  Working directory for the build
  -n, --image-name TEXT     Name for the Docker image
  -t, --image-tag TEXT      Tags for the Docker image (can be used multiple
                            times)
  -r, --registry TEXT       Docker registry URL
  -s, --namespace TEXT      Namespace for the Docker image
  --push / --no-push        Push image to registry after build
  -p, --platform TEXT       Platform for the Docker image
  --help                    Show this message and exit.
❌ Error: Unexpected error: 0

```

Currently:
```
❯ aenv build --help
Usage: aenv build [OPTIONS]

  Build Docker images with real-time progress display.

  This command builds Docker images from your project and provides real-time
  progress updates with beautiful UI components.

  Examples:     aenv build     aenv build --image-name myapp --image-tag v1.0
  aenv build --work-dir ./myproject --registry myregistry.com

Options:
  -w, --work-dir DIRECTORY  Working directory for the build
  -n, --image-name TEXT     Name for the Docker image
  -t, --image-tag TEXT      Tags for the Docker image (can be used multiple
                            times)
  -r, --registry TEXT       Docker registry URL
  -s, --namespace TEXT      Namespace for the Docker image
  --push / --no-push        Push image to registry after build
  -p, --platform TEXT       Platform for the Docker image
  --help                    Show this message and exit.
```