### PR TITLE
fix(aenv): pin transitive deps to coexist 

### DIFF
--- a/aenv/pyproject.toml
+++ b/aenv/pyproject.toml
@@ -24,15 +24,16 @@ classifiers = [
 ]
 
 dependencies = [
-    "pydantic>=1.10.0",
+    "pydantic>=2.7,<2.12",
+    "pydantic-settings>=2.0",
     "httpx>=0.20.0",
     "anyio>=3.0.0",
     "typing-extensions>=4.0.0",
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2",
     "uvicorn>=0.20.0",
     "click>=8.0.0",
     "requests>=2.25.0",
-    "fastmcp>=2.13.0",
+    "fastmcp>=2.13.0,<3",
     "rich>=13.0.0",
     "typer>=0.9.0",
     "tabulate>=0.9.0",


### PR DESCRIPTION
….x + pydantic 2.11.x)

aenv's PyPI metadata previously left fastmcp / mcp / pydantic upper-bounds open, so pip's resolver pulls:
  * fastmcp 3.x → pydantic-settings>=2.5 (latest) → pydantic 2.13.x
  * mcp >= 1.17 → pydantic-settings>=2.5.2 (forced)

That cascades to pydantic-core 2.41.x and breaks asap-service's LLM gateway which still relies on openai 1.78.1 + pydantic 2.11.10
+ pydantic-core 2.33.2 (openai 2.x SSE schema is incompatible).

Pin four deps to ranges that coexist with the asap pin set without sacrificing aenv's runtime contract:
  * pydantic >= 2.7, < 2.12   (asap is on 2.11.10)
  * pydantic-settings >= 2.0  (explicit so it isn't pulled by mcp alone)
  * mcp >= 1.0, < 2           (block future 2.x ABI break)
  * fastmcp >= 2.13, < 3      (block 3.x's stricter pydantic chain)

Local verification (asap-service Python env, OSX miniconda 3.12):
  * pip install aenvironment-0.1.6.whl -> openai 1.78.1 unchanged, pydantic 2.11.10 unchanged, pydantic-core 2.33.2 unchanged, fastmcp resolves to 2.14.7.
  * from aenv import Environment           -> OK
  * AEnvSandboxService._import_environment() -> aenv.core.environment.Environment
  * pytest biz/flash_game_agent/tests -m 'not integration' -> 11 passed.

openai-agents stays under [project.optional-dependencies].agents.