### PR TITLE
fix(aenv): preserve None env so arca keeps template default envs

### DIFF
--- a/aenv/pyproject.toml
+++ b/aenv/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aenvironment"
-version = "0.1.6"
+version = "0.1.8rc1"
 description = "AEnvironment Python SDK - Production-grade environment for AI agent tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/aenv/src/aenv/__init__.py
+++ b/aenv/src/aenv/__init__.py
@@ -35,7 +35,7 @@ from aenv.core.logging import setup_logging
 from aenv.core.models import EnvInstance, EnvStatus
 from aenv.core.tool import Tool, get_registry, register_tool
 
-__version__ = "0.1.6"
+__version__ = "0.1.8rc1"
 __all__ = [
     "Tool",
     "register_tool",

--- a/aenv/src/aenv/core/environment.py
+++ b/aenv/src/aenv/core/environment.py
@@ -159,7 +159,7 @@ class Environment:
         """
         self.env_name = env_name
         self.datasource = datasource
-        self.environment_variables = environment_variables or {}
+        self.environment_variables = environment_variables
         self.arguments = arguments or []
         self.dummy_instance_ip = os.getenv("DUMMY_INSTANCE_IP")
         self.skip_for_healthy = skip_for_healthy
@@ -1017,12 +1017,17 @@ class Environment:
             # Parse env_name to extract name and version
             env_name_parsed, env_version_parsed = split_env_name_version(self.env_name)
 
-            # Inject system environment variables envNAME and envversion
-            env_vars = (
-                dict(self.environment_variables) if self.environment_variables else {}
-            )
-            env_vars["envNAME"] = env_name_parsed
-            env_vars["envversion"] = env_version_parsed
+            # Inject system environment variables envNAME and envversion only
+            # when the caller provided env vars. When environment_variables is
+            # None the field must stay omitted end-to-end (api-service coerces
+            # to nil, arca keeps the env-config startup vars); injecting here
+            # would turn "no override" into a non-empty map that wipes them.
+            if self.environment_variables is None:
+                env_vars = None
+            else:
+                env_vars = dict(self.environment_variables)
+                env_vars["envNAME"] = env_name_parsed
+                env_vars["envversion"] = env_version_parsed
 
             self._instance = await self._client.create_env_instance(
                 name=self.env_name,


### PR DESCRIPTION
- __init__: stop washing environment_variables None -> {} at construction
- _create_env_instance: skip envNAME/envversion injection when env is None
- bump version to 0.1.8rc1